### PR TITLE
Add manual GH pages publish workflow

### DIFF
--- a/.github/manually-publish-gh-pages.yml
+++ b/.github/manually-publish-gh-pages.yml
@@ -1,0 +1,36 @@
+name: Manually Publish to GitHub Pages
+
+on:
+  workflow_dispatch:
+
+jobs:
+  publish-to-gh-pages:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Get Node.js version
+        id: nvm
+        run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
+      - uses: actions/setup-node@v2
+        with:
+          node-version: ${{ steps.nvm.outputs.NODE_VERSION }}
+      - name: Get Yarn cache directory
+        run: echo "::set-output name=YARN_CACHE_DIR::$(yarn cache dir)"
+        id: yarn-cache-dir
+      - name: Get Yarn version
+        run: echo "::set-output name=YARN_VERSION::$(yarn --version)"
+        id: yarn-version
+      - name: Cache yarn dependencies
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.yarn-cache-dir.outputs.YARN_CACHE_DIR }}
+          key: yarn-cache-${{ runner.os }}-${{ steps.yarn-version.outputs.YARN_VERSION }}-${{ hashFiles('yarn.lock') }}
+      - run: yarn --frozen-lockfile
+      - run: yarn build
+      - run: yarn build:website
+      - name: Publish to GitHub Pages
+        uses: MetaMask/action-publish-gh-pages@v2
+        with:
+          source-directory: public


### PR DESCRIPTION
Adds a GitHub Actions workflow for manually publishing to GitHub pages.