### PR TITLE
Update snaps documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # @metamask/template-snap
 
 The "Hello, world!" of MetaMask Snaps, and also a GitHub template repository.
-For instructions, see [the MetaMask documentation](https://docs.metamask.io/guide/snaps-tutorial.html).
+For instructions, see [the MetaMask documentation](https://docs.metamask.io/guide/snaps.html).
 
 ## Cloning
 


### PR DESCRIPTION
The link in the README was outdated and pointed at the wrong path.