### PR TITLE
feat: add Yarn `watch` script to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "build:website": "node ./scripts/build-website.js",
     "build": "mm-snap build",
     "serve": "mm-snap serve",
+    "watch": "mm-snap watch",
     "clean": "rimraf dist/*",
     "test": "echo 'TODO'",
     "lint:eslint": "eslint . --cache --ext js,ts",


### PR DESCRIPTION
`watch` will serve the bundle, but also re-bundle the snap's JS code when changed.