### PR TITLE
feat: make site build script use package.json name

### DIFF
--- a/scripts/build-website.js
+++ b/scripts/build-website.js
@@ -1,6 +1,7 @@
 const { promises: fs } = require('fs');
 const path = require('path');
 const mkdirp = require('mkdirp');
+const packageJson = require('../package.json');
 
 main();
 
@@ -24,7 +25,7 @@ async function main() {
     htmlContents.replace(
       // eslint-disable-next-line no-template-curly-in-string
       'const snapId = `local:${window.location.href}`;',
-      'const snapId = `npm:@metamask/template-snap`;',
+      `const snapId = 'npm:${packageJson.name}';`,
     ),
   );
 }


### PR DESCRIPTION
Use the `name` field of `package.json` in the site build script to replace the `local:` snapId with the ID of the current Snap.